### PR TITLE
Use req.param() and check http headers

### DIFF
--- a/lib/passport-hash/strategy.js
+++ b/lib/passport-hash/strategy.js
@@ -51,6 +51,7 @@ function Strategy(options, verify) {
   this.name = 'hash';
   this._verify = verify;
   this._passReqToCallback = options.passReqToCallback;
+  this._headerField = options.headerField || 'X-Auth-Hash';
 }
 
 /**
@@ -65,12 +66,11 @@ util.inherits(Strategy, passport.Strategy);
  * @api protected
  */
 Strategy.prototype.authenticate = function(req) {
-  if (!req.params || !req.params[this._hashParam]) {
+  var hash = req.param(this._hashParam) || req.get(this._headerField);
+  if (hash === undefined) {
     return this.fail(new BadRequestError('Missing hash parameter'));
   }
-  
-  var hash = req.params[this._hashParam];
-  
+
   var self = this;
   
   function verified(err, user, info) {


### PR DESCRIPTION
I'm not sure if passport-hash is meant to be used with Connect only, but in my setup I needed to use the Express methods instead - req.params[] wasn't working for my routing/API design. Unlike the current example, my app needs to grant API access through either a supplied hash (query param or X-Auth-Hash header) or basic authentication.
