### PR TITLE
changed dependency from passport to passport-strategy

### DIFF
--- a/lib/passport-hash/strategy.js
+++ b/lib/passport-hash/strategy.js
@@ -1,7 +1,7 @@
 /**
  * Module dependencies.
  */
-var passport = require('passport')
+var passport = require('passport-strategy')
   , util = require('util')
   , BadRequestError = require('./errors/badrequesterror');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-hash",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Hash authentication strategy for Passport.",
   "author": {
     "name": "Yuri Karadzhov",
@@ -17,7 +17,7 @@
   "main": "./lib/passport-hash",
   "dependencies": {
     "pkginfo": "*",
-    "passport": "^0.2.1"
+    "passport-strategy": "1.x.x"
   },
   "devDependencies": {
     "vows": "*"


### PR DESCRIPTION
In order to be compatible with passport 0.3.3, the dependency on old versions of passport must be changed.