### PR TITLE
Remove pkginfo

### DIFF
--- a/lib/passport-hash/index.js
+++ b/lib/passport-hash/index.js
@@ -4,11 +4,10 @@
 var Strategy = require('./strategy')
   , BadRequestError = require('./errors/badrequesterror');
 
-
 /**
  * Framework version.
  */
-require('pkginfo')(module, 'version');
+exports.version = require('../../package.json').version;
 
 /**
  * Expose constructors.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "test": "NODE_PATH=lib node_modules/.bin/vows test/*-test.js"
   },
-  "engines": { "node": ">= 0.4.0" },
+  "engines": { "node": ">= 0.6.0" },
   "licenses": [ {
     "type": "MIT",
     "url": "http://www.opensource.org/licenses/MIT"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   },
   "main": "./lib/passport-hash",
   "dependencies": {
-    "pkginfo": "*",
     "passport-strategy": "1.x.x"
   },
   "devDependencies": {
@@ -28,7 +27,7 @@
   "engines": { "node": ">= 0.4.0" },
   "licenses": [ {
     "type": "MIT",
-    "url": "http://www.opensource.org/licenses/MIT" 
+    "url": "http://www.opensource.org/licenses/MIT"
   } ],
   "keywords": [
     "passport",


### PR DESCRIPTION
pkginfo fails in webpack universal/isomorphic apps when try to  find **package.json**

``` shell
node_modules/pkginfo/lib/pkginfo.js:99
    throw new Error('Cannot find package.json from unspecified directory');
          ^
Error: Cannot find package.json from unspecified directory
```

Node require hook supports json since version 0.5.2 (0.6.0 stable)
